### PR TITLE
Remove include my_global.h in hoel-mariadb.c

### DIFF
--- a/src/hoel-mariadb.c
+++ b/src/hoel-mariadb.c
@@ -25,7 +25,6 @@
 
 #ifdef _HOEL_MARIADB
 /* MariaDB library Includes */
-#include <my_global.h>
 #include <mysql.h>
 #include <string.h>
 


### PR DESCRIPTION
 #warning This file should not be included by clients, include only <mysql.h>
Sous Slackware-current (mariadb-10.2, gcc-7.3), on a ce message d'erreur.
Supprimer la ligne ne pose aucun problème de compilation sous slackware-14.2 (mariadb-10.0, gcc-5.5), elle semble donc superflue. Glewlwyd compile et fonctionne sans problème, mais je ne l'utilise pas avec mariadb.
Je n'ai pas fait énormément de tests à ce sujet...