### PR TITLE
Fix trivial memory leak

### DIFF
--- a/src/hoel-sqlite.c
+++ b/src/hoel-sqlite.c
@@ -62,6 +62,7 @@ struct _h_connection * h_connect_sqlite(const char * db_path) {
                              sqlite3_errcode(((struct _h_sqlite *)conn->connection)->db_handle), 
                              sqlite3_errmsg(((struct _h_sqlite *)conn->connection)->db_handle));
       sqlite3_close(((struct _h_sqlite *)conn->connection)->db_handle);
+      free(conn->connection);
       free(conn);
       return NULL;
     } else {


### PR DESCRIPTION
A missing `free()`, though not in a very important place.