### PR TITLE
Improve memory error handling

### DIFF
--- a/src/hoel-simple-json.c
+++ b/src/hoel-simple-json.c
@@ -559,15 +559,6 @@ int h_select(const struct _h_connection * conn, const json_t * j_query, json_t *
     return H_ERROR_MEMORY;
   }
   
-  if (str_order_by == NULL) {
-    y_log_message(Y_LOG_LEVEL_ERROR, "Hoel - Error allocating memory for str_order_by");
-    o_free(columns);
-    o_free(where_clause);
-    o_free(str_where_limit);
-    o_free(str_order_by);
-    return H_ERROR_MEMORY;
-  }
-  
   query = msprintf("SELECT %s FROM %s WHERE %s %s %s", columns, table, where_clause, str_order_by, str_where_limit);
   if (query == NULL) {
     y_log_message(Y_LOG_LEVEL_DEBUG, "Hoel/h_select Error allocating query");

--- a/src/hoel-simple-json.c
+++ b/src/hoel-simple-json.c
@@ -537,15 +537,16 @@ int h_select(const struct _h_connection * conn, const json_t * j_query, json_t *
     } else {
       str_where_limit = msprintf("LIMIT %" JSON_INTEGER_FORMAT, limit);
     }
-    if (str_where_limit == NULL) {
-      y_log_message(Y_LOG_LEVEL_ERROR, "Hoel - Error allocating memory for str_where_limit");
-      o_free(columns);
-      o_free(where_clause);
-      return H_ERROR_MEMORY;
-    }
   } else {
     str_where_limit = o_strdup("");
   }
+  if (str_where_limit == NULL) {
+    y_log_message(Y_LOG_LEVEL_ERROR, "Hoel - Error allocating memory for str_where_limit");
+    o_free(columns);
+    o_free(where_clause);
+    return H_ERROR_MEMORY;
+  }
+
   if (order_by != NULL && json_is_string(order_by)) {
     str_order_by = msprintf("ORDER BY %s", json_string_value(order_by));
   } else {


### PR DESCRIPTION
The first error handling block missed the `else` case where a `o_strdup()` might fail.

The second error handling block was duplicated and tried to handle the same error as the block before.