### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,19 @@ jobs:
     - env: LABEL=cppcheck
       os: linux
       script:
-        - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 .
+        - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 . 
+    #powerjobs
+    - env: LABEL=gcc
+      compiler: gcc
+      arch: ppc64le
+    - env: LABEL=clang
+      compiler: clang
+      arch: ppc64le
+    - env: LABEL=cppcheck
+      os: linux
+      arch: ppc64le
+      script:
+        - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 .     
 
 script:
   - mkdir build && cd build


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
